### PR TITLE
Fix MSVC compilation error in types.hpp

### DIFF
--- a/src/types.hpp
+++ b/src/types.hpp
@@ -45,10 +45,10 @@ limitations under the License.
             #define snprintf _snprintf
         #endif
 
-        #if !defined(__x86_64__)
+        #if defined(_M_X64) && !defined(__x86_64__)
             #define __x86_64__  _M_X64
         #endif
-        #if !defined(__i386__)
+        #if defined(_M_IX86) && !defined(__i386__)
             #define __i386__  _M_IX86
         #endif
     #endif

--- a/src/types.hpp
+++ b/src/types.hpp
@@ -28,7 +28,7 @@ limitations under the License.
        typedef unsigned __int64   uint64_t;
        typedef __int64            int64_t;
     #else
-        #if __cplusplus >= 201103L
+        #if (__cplusplus >= 201103L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201103L)
             // C++11 or later
             #include <cstdint>
             #include <cstddef>
@@ -206,7 +206,7 @@ limitations under the License.
 
     namespace kanzi
     {
-#if __cplusplus >= 201703L
+#if (__cplusplus >= 201703L) || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L)
         using byte = std::byte;
 #else
         typedef uint8_t byte;


### PR DESCRIPTION
Hi, I'm using kanzi-cpp as a library in my project, and in the Windows runners, where I use MSVC and compile kanzi as a static library, I get this error:
```
D:\a\chisel\chisel\third_party\kanzi-cpp\src\transform\TextCodec.cpp(342,1): error C2872: 'byte': ambiguous symbol [D:\a\chisel\chisel\build\third_party\kanzi-cpp\libkanzi.vcxproj]
      C:\Program Files\Microsoft Visual Studio\18\Enterprise\VC\Tools\MSVC\14.51.36231\include\cstddef(34,24):
      could be 'std::byte'
      D:\a\chisel\chisel\third_party\kanzi-cpp\src\types.hpp(212,25):
      or       'kanzi::byte'
```
I've cloned your repository and took a look in types.hpp: you have written this comment
```
    // Notice: in Visual Studio (prior to VS2017 version 15.7)
    // __cplusplus always defaults to 199711L (aka C++98) !!! (unless
    // the extra option /Zc:__cplusplus is added to the command line).
    // Otherwise, using the _MSVC_LANG macro returns the proper C++ version.
```
but haven't applied the _MSVC_LANG checks in lines 31 (which imports cstddef) and 209 (which creates the byte macro). I've added these checks and the libkanzi target now compiles without this error.

Also, there is a similar problem when trying to compile with ARM64 as target on MSVC:
```
C:\a\chisel\chisel\third_party\kanzi-cpp\src\Memory.hpp(32,36): error C2065: '_MM_HINT_T0': undeclared identifier [C:\a\chisel\chisel\build\third_party\kanzi-cpp\libkanzi.vcxproj]
  (compiling source file '../../../third_party/kanzi-cpp/src/entropy/TPAQPredictor.cpp')

C:\a\chisel\chisel\third_party\kanzi-cpp\src\Memory.hpp(32,5): error C3861: '_mm_prefetch': identifier not found [C:\a\chisel\chisel\build\third_party\kanzi-cpp\libkanzi.vcxproj]
  (compiling source file '../../../third_party/kanzi-cpp/src/entropy/TPAQPredictor.cpp')
```
It is trying to use an intrinsic, defined like this
```
#elif defined(__x86_64__) || defined(_M_AMD64)
    _mm_prefetch((const char*)ptr, _MM_HINT_T0);
```
even though we are on ARM; the problem is still in types.hpp, line 49
```
#if !defined(__x86_64__)
    #define __x86_64__  _M_X64
#endif
```
where it is assumed that, since we are on Windows, then we must be on x86_64. A similar thing happens in the #if right below this; I fixed this by adding a check to see if _M_X64 (and _MIX86 under it) are actually defined, and libkanzi now compiles with no problems on my two Windows runners.